### PR TITLE
remove one-arg hash default

### DIFF
--- a/src/RiemannComplexNumbers.jl
+++ b/src/RiemannComplexNumbers.jl
@@ -99,7 +99,7 @@ end
 
 
 
-function hash(a::RC, h::UInt = UInt(0))
+function hash(a::RC, h::UInt)
     if isinf(a)
         return hash(Inf, h)
     end


### PR DESCRIPTION
the hash seed should not be given a default value as this inadvertently also creates a `Base.hash(::RC)` method which causes invalidations. also it causes hash bugs on 1.13+ and test failures in this package as the default seed has changed